### PR TITLE
stringify history with no whitespace

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -280,7 +280,7 @@ function pruneHistory(entries: HistoryEntry[]): HistoryEntry[] {
 }
 
 async function persistHistory() {
-  await fs.writeFile(getHistoryFilePath(), JSON.stringify(historyCache, null, 2), 'utf-8');
+  await fs.writeFile(getHistoryFilePath(), JSON.stringify(historyCache, null, 0), 'utf-8');
 }
 
 async function loadHistory() {


### PR DESCRIPTION
just small efficiency thing, it was bugging me

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * History data persistence has been optimized with a more compact file format for storage efficiency. This reduces the file footprint while maintaining complete data integrity, functionality, and accessibility. No impact on how history information is displayed or used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->