### PR TITLE
fix history shorcut documentation (it's Cmd+Y for MacOS)

### DIFF
--- a/src/components/AddressBar.tsx
+++ b/src/components/AddressBar.tsx
@@ -252,7 +252,7 @@ export default function AddressBar({ inputRef }: AddressBarProps) {
                 setMenuOpen(false);
               }}
             >
-              History ({primaryModifierLabel}+H)
+              History ({primaryModifierLabel}+{electron?.isMacOS ? "Y" : "H"})
             </button>
             <button
               type="button"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated keyboard shortcut display for the History menu to show correct platform-specific shortcuts (Cmd+Y on macOS, Ctrl+H on other platforms).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->